### PR TITLE
Update pfod.cpp

### DIFF
--- a/code/ardumower/pfod.cpp
+++ b/code/ardumower/pfod.cpp
@@ -730,7 +730,7 @@ void RemoteControl::sendBatteryMenu(boolean update){
   sendSlider("j12", F("Switch off if idle minutes"), robot->batSwitchOffIfIdle, "", 1, 300, 1);  
   sendSlider("j03", F("Switch off if below Volt"), robot->batSwitchOffIfBelow, "", 0.1, robot->batFull, (robot->batFull*0.72));  
      
-  sendSlider("j10", F("charging starts if Voltage is below"), robot->startChargingIfBelow, "", 0.1, robot->batFull);       
+  sendSlider("j10", F("charging starts if Voltage is below"), robot->startChargingIfBelow, "", 0.1, robot->batFull+2);       
   sendSlider("j11", F("Battery is fully charged if current is below"), robot->batFullCurrent, "", 0.1, robot->batChargingCurrentMax);       
   serialPort->println("}");
 }


### PR DESCRIPTION
"Charge start" slider needs to be able to go a bit over the Full voltage of the battery.  Otherwise if you touch the slider, you can now only set it to the max = battFull. If you try to charge manually and the charger gives out the same voltage as batFul, it will newer start charging.  So need to be able to set it a bit over batFull.